### PR TITLE
Added constant for exception

### DIFF
--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -27,6 +27,7 @@ class ApiException extends RequestException
     const FORECAST_PHRASE_INVALID = 76;
     const FORECAST_GEO_INVALID = 77;
     const FORECAST_NOT_AVAILABLE = 78;
+    const WORDSTAT_REPORT_IS_BEING_GENERATED = 92;
     const INVALID_CAMPAIGN_INFO = 111;
     const CAMPAIGNS_OVERFLOW = 114;
     const INVALID_BANNER_INFO = 151;


### PR DESCRIPTION
WORDSTAT_REPORT_IS_BEING_GENERATED error appears when you send request to create report in wordstat (YandexApiService::createNewWordstatReport) and then try to get report (YandexApiService::getWordstatReport) when it is not already generated.