### PR TITLE
ReportRequest - параметры отчёта.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@
   
 * Добавлена возможность повторного вызова метода API, если предыдущий вызов завершился
   с ошибкой и её можно классифицировать как временную.
+  
+* Изменена сигнатура методов у сервиса `Biplane\YandexDirect\Api\V5\Reports` (PR #8).
+
+  **Было**
+
+        get($reportDefinition, array $options = null);
+        getReady($reportDefinition, array $options = null, $retryInterval = null);
+        download($reportFile, $reportDefinition, array $options = null, $retryInterval = null);
+
+  **Стало**
+
+        get(ReportRequest $request);
+        getReady(ReportRequest $request, $retryInterval = null);
+        download($reportFile, ReportRequest $request, $retryInterval = null);
 
 ## 4.1.0-beta1 [commit logs](https://github.com/biplane/yandex-direct/compare/4.0.1...4.1.0-beta1)
 

--- a/src/Api/V5/Report/ReportOptions.php
+++ b/src/Api/V5/Report/ReportOptions.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Biplane\YandexDirect\Api\V5\Report;
+
+/**
+ * ReportOptions
+ *
+ * @author Denis Vasilev
+ */
+class ReportOptions
+{
+    const PROCESSING_MODE_AUTO = 'auto';
+    const PROCESSING_MODE_ONLINE = 'online';
+    const PROCESSING_MODE_OFFLINE = 'offline';
+
+    const RETURN_MONEY_FORMAT_MICROS = 1;
+    const RETURN_MONEY_FORMAT_FLOAT = 2;
+
+    private $processingMode = self::PROCESSING_MODE_AUTO;
+    private $returnMoneyFormat = self::RETURN_MONEY_FORMAT_MICROS;
+    private $skipColumnHeader = false;
+    private $skipReportHeader = false;
+    private $skipReportSummary = false;
+
+    public function getProcessingMode()
+    {
+        return $this->processingMode;
+    }
+
+    public function setProcessingMode($mode)
+    {
+        $allowedModes = [
+            self::PROCESSING_MODE_AUTO,
+            self::PROCESSING_MODE_ONLINE,
+            self::PROCESSING_MODE_OFFLINE
+        ];
+
+        if (!in_array($mode, $allowedModes)) {
+            throw new \InvalidArgumentException(sprintf(
+                'The mode must be one of the following values: %s',
+                implode(', ', $allowedModes)
+            ));
+        }
+
+        $this->processingMode = $mode;
+
+        return $this;
+    }
+
+    public function getReturnMoneyFormat()
+    {
+        return $this->returnMoneyFormat;
+    }
+
+    public function returnMoneyInMicros()
+    {
+        $this->returnMoneyFormat = self::RETURN_MONEY_FORMAT_MICROS;
+
+        return $this;
+    }
+
+    public function returnMoneyAsFloat()
+    {
+        $this->returnMoneyFormat = self::RETURN_MONEY_FORMAT_FLOAT;
+
+        return $this;
+    }
+
+    public function isSkipColumnHeader()
+    {
+        return $this->skipColumnHeader;
+    }
+
+    public function skipColumnHeader()
+    {
+        $this->skipColumnHeader = true;
+
+        return $this;
+    }
+
+    public function includeColumnHeader()
+    {
+        $this->skipColumnHeader = false;
+
+        return $this;
+    }
+
+    public function isSkipReportHeader()
+    {
+        return $this->skipReportHeader;
+    }
+
+    public function skipReportHeader()
+    {
+        $this->skipReportHeader = true;
+
+        return $this;
+    }
+
+    public function includeReportHeader()
+    {
+        $this->skipReportHeader = false;
+
+        return $this;
+    }
+
+    public function isSkipReportSummary()
+    {
+        return $this->skipReportSummary;
+    }
+
+    public function skipReportSummary()
+    {
+        $this->skipReportSummary = true;
+
+        return $this;
+    }
+
+    public function includeReportSummary()
+    {
+        $this->skipReportSummary = false;
+
+        return $this;
+    }
+}

--- a/src/Api/V5/Report/ReportRequest.php
+++ b/src/Api/V5/Report/ReportRequest.php
@@ -3,11 +3,11 @@
 namespace Biplane\YandexDirect\Api\V5\Report;
 
 /**
- * ReportOptions
+ * ReportRequest.
  *
  * @author Denis Vasilev
  */
-class ReportOptions
+class ReportRequest
 {
     const PROCESSING_MODE_AUTO = 'auto';
     const PROCESSING_MODE_ONLINE = 'online';
@@ -21,6 +21,7 @@ class ReportOptions
     private $skipColumnHeader = false;
     private $skipReportHeader = false;
     private $skipReportSummary = false;
+    private $definition;
 
     public function getProcessingMode()
     {
@@ -119,6 +120,34 @@ class ReportOptions
     public function includeReportSummary()
     {
         $this->skipReportSummary = false;
+
+        return $this;
+    }
+
+    /**
+     * Gets the report definition.
+     *
+     * @return string
+     */
+    public function getDefinition()
+    {
+        return $this->definition;
+    }
+
+    /**
+     * Sets the report definition.
+     *
+     * @param ReportDefinitionBuilder|string $reportDefinition The report definition, XML document
+     *
+     * @return self
+     */
+    public function setDefinition($reportDefinition)
+    {
+        if ($reportDefinition instanceof ReportDefinitionBuilder) {
+            $reportDefinition = $reportDefinition->build();
+        }
+
+        $this->definition = $reportDefinition;
 
         return $this;
     }

--- a/tests/YandexDirect/Api/V5/ReportsTest.php
+++ b/tests/YandexDirect/Api/V5/ReportsTest.php
@@ -2,6 +2,7 @@
 
 namespace Biplane\Tests\YandexDirect\Api\V5;
 
+use Biplane\YandexDirect\Api\V5\Report\ReportOptions;
 use Biplane\YandexDirect\Api\V5\Reports;
 use Biplane\YandexDirect\Exception\ApiException;
 use Biplane\YandexDirect\User;
@@ -89,6 +90,12 @@ class ReportsTest extends \PHPUnit_Framework_TestCase
     public function testCreateReportWithCustomOptions()
     {
         $reportDefinition = '<ReportDefinition />';
+        $reportOptions = (new ReportOptions())
+            ->setProcessingMode(ReportOptions::PROCESSING_MODE_OFFLINE)
+            ->returnMoneyAsFloat()
+            ->skipColumnHeader()
+            ->skipReportHeader()
+            ->skipReportSummary();
 
         $this->mockHandler->append(new Response(201));
 
@@ -97,13 +104,7 @@ class ReportsTest extends \PHPUnit_Framework_TestCase
             'login' => 'bar'
         ]);
 
-        $result = $service->get($reportDefinition, [
-            'processing_mode' => 'offline',
-            'return_money_in_micros' => false,
-            'skip_report_header' => true,
-            'skip_column_header' => true,
-            'skip_report_summary' => true,
-        ]);
+        $result = $service->get($reportDefinition, $reportOptions);
 
         $this->assertFalse($result->isReady());
         $this->assertRequest($this->mockHandler->getLastRequest(), $reportDefinition, [

--- a/tests/YandexDirect/Api/V5/ReportsTest.php
+++ b/tests/YandexDirect/Api/V5/ReportsTest.php
@@ -2,7 +2,7 @@
 
 namespace Biplane\Tests\YandexDirect\Api\V5;
 
-use Biplane\YandexDirect\Api\V5\Report\ReportOptions;
+use Biplane\YandexDirect\Api\V5\Report\ReportRequest;
 use Biplane\YandexDirect\Api\V5\Reports;
 use Biplane\YandexDirect\Exception\ApiException;
 use Biplane\YandexDirect\User;
@@ -26,7 +26,8 @@ class ReportsTest extends \PHPUnit_Framework_TestCase
 
     public function testGetResultWhenNewReportIsCreated()
     {
-        $reportDefinition = '<ReportDefinition />';
+        $reportRequest = (new ReportRequest())
+            ->setDefinition('<ReportDefinition />');
 
         $this->mockHandler->append(new Response(201));
 
@@ -35,10 +36,10 @@ class ReportsTest extends \PHPUnit_Framework_TestCase
             'login' => 'bar'
         ]);
 
-        $result = $service->get($reportDefinition);
+        $result = $service->get($reportRequest);
 
         $this->assertFalse($result->isReady());
-        $this->assertRequest($this->mockHandler->getLastRequest(), $reportDefinition, [
+        $this->assertRequest($this->mockHandler->getLastRequest(), $reportRequest->getDefinition(), [
             'Authorization' => 'Bearer foo',
             'Accept-Language' => 'en',
             'Client-Login' => 'bar',
@@ -48,7 +49,8 @@ class ReportsTest extends \PHPUnit_Framework_TestCase
 
     public function testGetResultWhenReportIsProcessing()
     {
-        $reportDefinition = '<ReportDefinition />';
+        $reportRequest = (new ReportRequest())
+            ->setDefinition('<ReportDefinition />');
 
         $this->mockHandler->append(new Response(202));
 
@@ -58,10 +60,10 @@ class ReportsTest extends \PHPUnit_Framework_TestCase
             'login' => 'bar'
         ]);
 
-        $result = $service->get($reportDefinition);
+        $result = $service->get($reportRequest);
 
         $this->assertFalse($result->isReady());
-        $this->assertRequest($this->mockHandler->getLastRequest(), $reportDefinition, [
+        $this->assertRequest($this->mockHandler->getLastRequest(), $reportRequest->getDefinition(), [
             'Authorization' => 'Bearer foo',
             'Accept-Language' => 'ru',
             'Client-Login' => 'bar',
@@ -71,7 +73,8 @@ class ReportsTest extends \PHPUnit_Framework_TestCase
 
     public function testGetResultWhenReportIsReady()
     {
-        $reportDefinition = '<ReportDefinition />';
+        $reportRequest = (new ReportRequest())
+            ->setDefinition('<ReportDefinition />');
         $reportContent = 'report data';
 
         $this->mockHandler->append(new Response(200, [], $reportContent));
@@ -81,7 +84,7 @@ class ReportsTest extends \PHPUnit_Framework_TestCase
             'login' => 'bar'
         ]);
 
-        $result = $service->get($reportDefinition);
+        $result = $service->get($reportRequest);
 
         $this->assertTrue($result->isReady());
         $this->assertEquals($reportContent, $result->getData());
@@ -89,9 +92,9 @@ class ReportsTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateReportWithCustomOptions()
     {
-        $reportDefinition = '<ReportDefinition />';
-        $reportOptions = (new ReportOptions())
-            ->setProcessingMode(ReportOptions::PROCESSING_MODE_OFFLINE)
+        $reportRequest = (new ReportRequest())
+            ->setDefinition('<ReportDefinition />')
+            ->setProcessingMode(ReportRequest::PROCESSING_MODE_OFFLINE)
             ->returnMoneyAsFloat()
             ->skipColumnHeader()
             ->skipReportHeader()
@@ -104,10 +107,10 @@ class ReportsTest extends \PHPUnit_Framework_TestCase
             'login' => 'bar'
         ]);
 
-        $result = $service->get($reportDefinition, $reportOptions);
+        $result = $service->get($reportRequest);
 
         $this->assertFalse($result->isReady());
-        $this->assertRequest($this->mockHandler->getLastRequest(), $reportDefinition, [
+        $this->assertRequest($this->mockHandler->getLastRequest(), $reportRequest->getDefinition(), [
             'Authorization' => 'Bearer foo',
             'Accept-Language' => 'en',
             'Client-Login' => 'bar',
@@ -121,7 +124,8 @@ class ReportsTest extends \PHPUnit_Framework_TestCase
 
     public function testWaitBuildingReport()
     {
-        $reportDefinition = '<ReportDefinition />';
+        $reportRequest = (new ReportRequest())
+            ->setDefinition('<ReportDefinition />');
         $reportContent = 'report data';
 
         $this->mockHandler->append(
@@ -137,7 +141,7 @@ class ReportsTest extends \PHPUnit_Framework_TestCase
             'login' => 'bar'
         ]);
 
-        $result = $service->getReady($reportDefinition);
+        $result = $service->getReady($reportRequest);
 
         $this->assertTrue($result->isReady());
         $this->assertEquals($reportContent, $result->getData());
@@ -145,7 +149,8 @@ class ReportsTest extends \PHPUnit_Framework_TestCase
 
     public function testDownloadReport()
     {
-        $reportDefinition = '<ReportDefinition />';
+        $reportRequest = (new ReportRequest())
+            ->setDefinition('<ReportDefinition />');
         $reportContent = 'report data';
 
         $this->mockHandler->append(
@@ -158,7 +163,7 @@ class ReportsTest extends \PHPUnit_Framework_TestCase
             'login' => 'bar'
         ]);
 
-        $service->download($this->reportFile, $reportDefinition);
+        $service->download($this->reportFile, $reportRequest);
 
         $requestOptions = $this->mockHandler->getLastOptions();
 
@@ -172,7 +177,8 @@ class ReportsTest extends \PHPUnit_Framework_TestCase
      */
     public function testThrowApiExceptionWhenBadRequest()
     {
-        $reportDefinition = '<ReportDefinition />';
+        $reportRequest = (new ReportRequest())
+            ->setDefinition('<ReportDefinition />');
         $reportDownloadError = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <reports:reportDownloadError xmlns:reports="http://api.direct.yandex.com/v5/reports">
@@ -192,7 +198,7 @@ XML;
         ]);
 
         try {
-            $service->get($reportDefinition);
+            $service->get($reportRequest);
         } catch (ApiException $ex) {
             $this->assertEquals('Reports:get', $ex->getMethodRef());
             $this->assertEquals('2773184281650080533', $ex->getRequestId());
@@ -209,7 +215,8 @@ XML;
      */
     public function testThrowNetworkException()
     {
-        $reportDefinition = '<ReportDefinition />';
+        $reportRequest = (new ReportRequest())
+            ->setDefinition('<ReportDefinition />');
 
         $this->mockHandler->append(new Response(500, [], 'Internal server error'));
 
@@ -221,12 +228,13 @@ XML;
             }
         ]);
 
-        $service->get($reportDefinition);
+        $service->get($reportRequest);
     }
 
     public function testReportFileShouldBeEmptyWhenDownloadFailed()
     {
-        $reportDefinition = '<ReportDefinition />';
+        $reportRequest = (new ReportRequest())
+            ->setDefinition('<ReportDefinition />');
         $reportDownloadError = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <reports:reportDownloadError xmlns:reports="http://api.direct.yandex.com/v5/reports">
@@ -246,7 +254,7 @@ XML;
         ]);
 
         try {
-            $service->download($this->reportFile, $reportDefinition);
+            $service->download($this->reportFile, $reportRequest);
         } catch (\Exception $ex) {
         }
 


### PR DESCRIPTION
Класс `ReportRequest` предоставляет более удобный API (DSL) для конфигурации создаваемого отчёта. Обеспечивает больше согласованности с другими сервисами API 5.

```php
$request = (new ReportRequest())
    ->returnMoneyAsFloat()
    ->setProcessingMode(ReportOptions::PROCESSING_MODE_ONLINE)
    ->skipReportSummary()
    ->setDefinition(...); // строка с XML-документом или объект ReportDefinitionBuilder

$result = $reportService->get($request);
```

В этом примере при запросе к API отчётов будут заданы заголовки:

    processingMode: online
    returnMoneyInMicros: false
    skipReportSummary: true