### PR TITLE
fix incompatibility with SoapClient::__soapCall

### DIFF
--- a/src/Api/ApiSoapClientV4.php
+++ b/src/Api/ApiSoapClientV4.php
@@ -56,7 +56,7 @@ class ApiSoapClientV4 extends ApiSoapClient
      *
      * @internal
      */
-    public function __doRequest($request, $location, $action, $version, $oneWay = 0)
+    public function __doRequest($request, $location, $action, $version, $oneWay = 0): ?string
     {
         $response = parent::__doRequest($request, $location, $action, $version, $oneWay);
 

--- a/src/Soap/ApiSoapClient.php
+++ b/src/Soap/ApiSoapClient.php
@@ -14,6 +14,7 @@ use Biplane\YandexDirect\Runner\Runner;
 use Biplane\YandexDirect\Soap\TypeConverter\DecimalTypeConverter;
 use InvalidArgumentException;
 use ReflectionClass;
+use ReturnTypeWillChange;
 use RuntimeException;
 use SoapClient;
 use SoapFault;
@@ -178,6 +179,7 @@ abstract class ApiSoapClient extends SoapClient implements ClientInterface
     /**
      * {@inheritDoc}
      */
+    #[ReturnTypeWillChange]
     public function __soapCall($name, $args, $options = null, $inputHeaders = null, &$outputHeaders = null)
     {
         if ($this->eventEmitter !== null) {


### PR DESCRIPTION
Fixes
```
Return type of Biplane\YandexDirect\Soap\ApiSoapClient::__soapCall($name, $args, $options = null, $inputHeaders = null, &$outputHeaders = null) should either be compatible with SoapClient::__soapCall(string $name, array $args, ?array $options = null, $inputHeaders = null, &$outputHeaders = null): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```