### PR TITLE
Removed dot-to-dash substitution in client_login

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -150,7 +150,10 @@ final class Config
             ->setAllowedTypes('soap_options', [SoapOptions::class])
             ->setNormalizer('client_login', static function (Options $options, $value) {
                 if (is_string($value)) {
-                    return strtolower($value);
+                    $exploded = explode('@', $value);
+                    $exploded[0] = str_replace('.', '-', $exploded[0]);
+
+                    return strtolower(implode('@', $exploded));
                 }
 
                 return $value;

--- a/src/Config.php
+++ b/src/Config.php
@@ -150,7 +150,7 @@ final class Config
             ->setAllowedTypes('soap_options', [SoapOptions::class])
             ->setNormalizer('client_login', static function (Options $options, $value) {
                 if (is_string($value)) {
-                    return strtolower(str_replace('.', '-', $value));
+                    return strtolower($value);
                 }
 
                 return $value;

--- a/src/Config.php
+++ b/src/Config.php
@@ -9,6 +9,8 @@ use Symfony\Component\OptionsResolver\Exception\InvalidArgumentException;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+use function explode;
+use function implode;
 use function is_string;
 use function sprintf;
 use function str_replace;


### PR DESCRIPTION
В директе доступны логины вида name@domain и при замене точки на тире получаем ошибку вида 

` Объект не найден: В HTTP-заголовке Client-Login указан несуществующий логин`

Предлагаю оставить только strtolower 